### PR TITLE
GoogleChrome-72.0.3626.96

### DIFF
--- a/catalogs/production
+++ b/catalogs/production
@@ -7,68 +7,6 @@
 		<false/>
 		<key>catalogs</key>
 		<array>
-			<string>testing</string>
-		</array>
-		<key>description</key>
-		<string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
-		<key>display_name</key>
-		<string>Google Chrome</string>
-		<key>installer_item_hash</key>
-		<string>ddb68d2976adcc6f1bcf005ab21a395e5028352c76ff7e700e10e1e57f8cac95</string>
-		<key>installer_item_location</key>
-		<string>apps/GoogleChrome-71.0.3578.98.dmg</string>
-		<key>installer_item_size</key>
-		<integer>74265</integer>
-		<key>installer_type</key>
-		<string>copy_from_dmg</string>
-		<key>installs</key>
-		<array>
-			<dict>
-				<key>CFBundleIdentifier</key>
-				<string>com.google.Chrome</string>
-				<key>CFBundleName</key>
-				<string>Chrome</string>
-				<key>CFBundleShortVersionString</key>
-				<string>71.0.3578.98</string>
-				<key>CFBundleVersion</key>
-				<string>3578.98</string>
-				<key>minosversion</key>
-				<string>10.10.0</string>
-				<key>path</key>
-				<string>/Applications/Google Chrome.app</string>
-				<key>type</key>
-				<string>application</string>
-				<key>version_comparison_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-		</array>
-		<key>items_to_copy</key>
-		<array>
-			<dict>
-				<key>destination_path</key>
-				<string>/Applications</string>
-				<key>source_item</key>
-				<string>Google Chrome.app</string>
-			</dict>
-		</array>
-		<key>minimum_os_version</key>
-		<string>10.10.0</string>
-		<key>name</key>
-		<string>GoogleChrome</string>
-		<key>unattended_install</key>
-		<true/>
-		<key>uninstall_method</key>
-		<string>remove_copied_items</string>
-		<key>uninstallable</key>
-		<true/>
-		<key>version</key>
-		<string>71.0.3578.98</string>
-	</dict>
-	<dict>
-		<key>autoremove</key>
-		<false/>
-		<key>catalogs</key>
-		<array>
 			<string>production</string>
 		</array>
 		<key>description</key>

--- a/pkgs/apps/GoogleChrome-72.0.3626.96.dmg
+++ b/pkgs/apps/GoogleChrome-72.0.3626.96.dmg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eff59f3cb7b93a85eb751a549126d6e8253b26273df25083967d9c28ee32c4f5
+size 76294295

--- a/pkgsinfo/apps/GoogleChrome-72.0.3626.96.plist
+++ b/pkgsinfo/apps/GoogleChrome-72.0.3626.96.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_metadata</key>
+	<dict>
+		<key>created_by</key>
+		<string>distiller</string>
+		<key>creation_date</key>
+		<date>2019-02-06T20:02:14Z</date>
+		<key>munki_version</key>
+		<string>3.5.2.3637</string>
+		<key>os_version</key>
+		<string>10.13.6</string>
+	</dict>
+	<key>autoremove</key>
+	<false/>
+	<key>catalogs</key>
+	<array>
+		<string>production</string>
+	</array>
+	<key>description</key>
+	<string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
+	<key>display_name</key>
+	<string>Google Chrome</string>
+	<key>installer_item_hash</key>
+	<string>eff59f3cb7b93a85eb751a549126d6e8253b26273df25083967d9c28ee32c4f5</string>
+	<key>installer_item_location</key>
+	<string>apps/GoogleChrome-72.0.3626.96.dmg</string>
+	<key>installer_item_size</key>
+	<integer>74506</integer>
+	<key>installer_type</key>
+	<string>copy_from_dmg</string>
+	<key>installs</key>
+	<array>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.google.Chrome</string>
+			<key>CFBundleName</key>
+			<string>Chrome</string>
+			<key>CFBundleShortVersionString</key>
+			<string>72.0.3626.96</string>
+			<key>CFBundleVersion</key>
+			<string>3626.96</string>
+			<key>minosversion</key>
+			<string>10.10.0</string>
+			<key>path</key>
+			<string>/Applications/Google Chrome.app</string>
+			<key>type</key>
+			<string>application</string>
+			<key>version_comparison_key</key>
+			<string>CFBundleShortVersionString</string>
+		</dict>
+	</array>
+	<key>items_to_copy</key>
+	<array>
+		<dict>
+			<key>destination_path</key>
+			<string>/Applications</string>
+			<key>source_item</key>
+			<string>Google Chrome.app</string>
+		</dict>
+	</array>
+	<key>minimum_os_version</key>
+	<string>10.10.0</string>
+	<key>name</key>
+	<string>GoogleChrome</string>
+	<key>unattended_install</key>
+	<true/>
+	<key>uninstall_method</key>
+	<string>remove_copied_items</string>
+	<key>uninstallable</key>
+	<true/>
+	<key>version</key>
+	<string>72.0.3626.96</string>
+</dict>
+</plist>


### PR DESCRIPTION
{"pkg_repo_path": "apps/GoogleChrome-72.0.3626.96.dmg", "pkginfo_path": "apps/GoogleChrome-72.0.3626.96.plist", "version": "72.0.3626.96", "catalogs": "production", "name": "GoogleChrome"}