### PR TITLE
GoogleChrome-73.0.3683.86

### DIFF
--- a/catalogs/production
+++ b/catalogs/production
@@ -7,68 +7,6 @@
 		<false/>
 		<key>catalogs</key>
 		<array>
-			<string>testing</string>
-		</array>
-		<key>description</key>
-		<string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
-		<key>display_name</key>
-		<string>Google Chrome</string>
-		<key>installer_item_hash</key>
-		<string>ddb68d2976adcc6f1bcf005ab21a395e5028352c76ff7e700e10e1e57f8cac95</string>
-		<key>installer_item_location</key>
-		<string>apps/GoogleChrome-71.0.3578.98.dmg</string>
-		<key>installer_item_size</key>
-		<integer>74265</integer>
-		<key>installer_type</key>
-		<string>copy_from_dmg</string>
-		<key>installs</key>
-		<array>
-			<dict>
-				<key>CFBundleIdentifier</key>
-				<string>com.google.Chrome</string>
-				<key>CFBundleName</key>
-				<string>Chrome</string>
-				<key>CFBundleShortVersionString</key>
-				<string>71.0.3578.98</string>
-				<key>CFBundleVersion</key>
-				<string>3578.98</string>
-				<key>minosversion</key>
-				<string>10.10.0</string>
-				<key>path</key>
-				<string>/Applications/Google Chrome.app</string>
-				<key>type</key>
-				<string>application</string>
-				<key>version_comparison_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-		</array>
-		<key>items_to_copy</key>
-		<array>
-			<dict>
-				<key>destination_path</key>
-				<string>/Applications</string>
-				<key>source_item</key>
-				<string>Google Chrome.app</string>
-			</dict>
-		</array>
-		<key>minimum_os_version</key>
-		<string>10.10.0</string>
-		<key>name</key>
-		<string>GoogleChrome</string>
-		<key>unattended_install</key>
-		<true/>
-		<key>uninstall_method</key>
-		<string>remove_copied_items</string>
-		<key>uninstallable</key>
-		<true/>
-		<key>version</key>
-		<string>71.0.3578.98</string>
-	</dict>
-	<dict>
-		<key>autoremove</key>
-		<false/>
-		<key>catalogs</key>
-		<array>
 			<string>production</string>
 		</array>
 		<key>description</key>

--- a/pkgs/apps/GoogleChrome-73.0.3683.86.dmg
+++ b/pkgs/apps/GoogleChrome-73.0.3683.86.dmg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:757054e3fb47b67403bc46f2ce72570d2aa55bc80c401323dc0563afdd7d46ab
+size 77970621

--- a/pkgsinfo/apps/GoogleChrome-73.0.3683.86.plist
+++ b/pkgsinfo/apps/GoogleChrome-73.0.3683.86.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_metadata</key>
+	<dict>
+		<key>created_by</key>
+		<string>distiller</string>
+		<key>creation_date</key>
+		<date>2019-03-21T09:55:23Z</date>
+		<key>munki_version</key>
+		<string>3.5.2.3637</string>
+		<key>os_version</key>
+		<string>10.13.6</string>
+	</dict>
+	<key>autoremove</key>
+	<false/>
+	<key>catalogs</key>
+	<array>
+		<string>production</string>
+	</array>
+	<key>description</key>
+	<string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
+	<key>display_name</key>
+	<string>Google Chrome</string>
+	<key>installer_item_hash</key>
+	<string>757054e3fb47b67403bc46f2ce72570d2aa55bc80c401323dc0563afdd7d46ab</string>
+	<key>installer_item_location</key>
+	<string>apps/GoogleChrome-73.0.3683.86.dmg</string>
+	<key>installer_item_size</key>
+	<integer>76143</integer>
+	<key>installer_type</key>
+	<string>copy_from_dmg</string>
+	<key>installs</key>
+	<array>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.google.Chrome</string>
+			<key>CFBundleName</key>
+			<string>Chrome</string>
+			<key>CFBundleShortVersionString</key>
+			<string>73.0.3683.86</string>
+			<key>CFBundleVersion</key>
+			<string>3683.86</string>
+			<key>minosversion</key>
+			<string>10.10.0</string>
+			<key>path</key>
+			<string>/Applications/Google Chrome.app</string>
+			<key>type</key>
+			<string>application</string>
+			<key>version_comparison_key</key>
+			<string>CFBundleShortVersionString</string>
+		</dict>
+	</array>
+	<key>items_to_copy</key>
+	<array>
+		<dict>
+			<key>destination_path</key>
+			<string>/Applications</string>
+			<key>source_item</key>
+			<string>Google Chrome.app</string>
+		</dict>
+	</array>
+	<key>minimum_os_version</key>
+	<string>10.10.0</string>
+	<key>name</key>
+	<string>GoogleChrome</string>
+	<key>unattended_install</key>
+	<true/>
+	<key>uninstall_method</key>
+	<string>remove_copied_items</string>
+	<key>uninstallable</key>
+	<true/>
+	<key>version</key>
+	<string>73.0.3683.86</string>
+</dict>
+</plist>


### PR DESCRIPTION
{"pkg_repo_path": "apps/GoogleChrome-73.0.3683.86.dmg", "pkginfo_path": "apps/GoogleChrome-73.0.3683.86.plist", "version": "73.0.3683.86", "catalogs": "production", "name": "GoogleChrome"}